### PR TITLE
if search mode and set --db-user, no filter servelress

### DIFF
--- a/client.go
+++ b/client.go
@@ -319,6 +319,9 @@ func (client *Client) getCredentialsForServerless(ctx context.Context, input *Ge
 			input.port = aws.String(fmt.Sprintf("%d", *workgroup.Workgroup.Endpoint.Port))
 		}
 	}
+	if input.DbUser != nil {
+		client.logger.Println("[warn] The db user setting is ignored.")
+	}
 	return &GetCredentialsOutput{
 		WorkgroupName:   input.WorkgroupName,
 		Endpoint:        input.address,


### PR DESCRIPTION
If cluster and workgroup are not specified, simply search all. Even if a db-user is specified, you can still use